### PR TITLE
PR #423 with local mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/seedsigner/models/settings_definition.json
 .idea
 *.mo
 .coverage
+seedsigner-screenshots

--- a/tests/screenshot_generator/README.md
+++ b/tests/screenshot_generator/README.md
@@ -5,4 +5,4 @@ From the project root, run:
 pytest tests/screenshot_generator/generator.py
 ```
 
-By default it writes the screenshots to a dir that's parallel to the project root: `seedsigner-screenshots`.
+Writes the screenshots to a dir in the project root: `seedsigner-screenshots`.

--- a/tests/screenshot_generator/generator.py
+++ b/tests/screenshot_generator/generator.py
@@ -1,9 +1,17 @@
 import embit
 import os
-import pathlib
-import pytest
-import shutil
-from mock import Mock, patch
+import sys
+from mock import Mock, patch, MagicMock
+
+# Prevent importing modules w/Raspi hardware dependencies.
+# These must precede any SeedSigner imports.
+sys.modules['seedsigner.hardware.ST7789'] = MagicMock()
+sys.modules['seedsigner.gui.screens.screensaver'] = MagicMock()
+sys.modules['seedsigner.views.screensaver'] = MagicMock()
+sys.modules['seedsigner.hardware.buttons'] = MagicMock()
+sys.modules['seedsigner.hardware.camera'] = MagicMock()
+sys.modules['seedsigner.hardware.microsd'] = MagicMock()
+
 
 from seedsigner.controller import Controller
 from seedsigner.gui.renderer import Renderer
@@ -18,7 +26,7 @@ from seedsigner.views import (MainMenuView, PowerOptionsView, RestartView, NotYe
     psbt_views, scan_views, seed_views, settings_views, tools_views)
 from seedsigner.views.view import View
 
-from .utils import ScreenshotComplete, ScreenshotRenderer
+from tests.screenshot_generator.utils import ScreenshotComplete, ScreenshotRenderer
 
 
 
@@ -30,12 +38,8 @@ def test_generate_screenshots(target_locale):
         When the `Renderer` instance is needed, we patch in our own test-only
         `ScreenshotRenderer`.
     """
-    # Disable hardware dependencies by essentially wiping out this class
-    HardwareButtons.get_instance = Mock()
-    Camera.get_instance = Mock()
-
     # Prep the ScreenshotRenderer that will be patched over the normal Renderer
-    screenshot_root = "/home/pi/seedsigner-screenshots"
+    screenshot_root = os.path.join(os.getcwd(), "seedsigner-screenshots")
     ScreenshotRenderer.configure_instance()
     screenshot_renderer: ScreenshotRenderer = ScreenshotRenderer.get_instance()
 

--- a/tests/screenshot_generator/utils.py
+++ b/tests/screenshot_generator/utils.py
@@ -3,8 +3,10 @@ from PIL import Image, ImageDraw
 from seedsigner.gui.renderer import Renderer
 
 
+
 class ScreenshotComplete(Exception):
     pass
+
 
 
 class ScreenshotRenderer(Renderer):


### PR DESCRIPTION
Slight changes so the screenshot generator can run in local dev with no Raspi hardware dependencies!

Also changes the output dir to be inside the project root.